### PR TITLE
dpdk compilation & access to driver name

### DIFF
--- a/app/test-pmd/cmdline.c
+++ b/app/test-pmd/cmdline.c
@@ -6826,7 +6826,6 @@ cmd_set_vf_rxmode_parsed(void *parsed_result,
 	uint16_t rx_mode = 0;
 	struct cmd_set_vf_rxmode *res = parsed_result;
 
-	int is_on = (strcmp(res->on, "on") == 0) ? 1 : 0;
 	if (!strcmp(res->what,"rxmode")) {
 		if (!strcmp(res->mode, "AUPE"))
 			rx_mode |= ETH_VMDQ_ACCEPT_UNTAG;
@@ -6839,11 +6838,13 @@ cmd_set_vf_rxmode_parsed(void *parsed_result,
 	}
 
 #ifdef RTE_LIBRTE_IXGBE_PMD
+	int is_on = (strcmp(res->on, "on") == 0) ? 1 : 0;
 	if (ret == -ENOTSUP)
 		ret = rte_pmd_ixgbe_set_vf_rxmode(res->port_id, res->vf_id,
 						  rx_mode, (uint8_t)is_on);
 #endif
 #ifdef RTE_LIBRTE_BNXT_PMD
+	int is_on = (strcmp(res->on, "on") == 0) ? 1 : 0;
 	if (ret == -ENOTSUP)
 		ret = rte_pmd_bnxt_set_vf_rxmode(res->port_id, res->vf_id,
 						 rx_mode, (uint8_t)is_on);

--- a/app/test-pmd/config.c
+++ b/app/test-pmd/config.c
@@ -3048,6 +3048,9 @@ set_queue_rate_limit(portid_t port_id, uint16_t queue_idx, uint16_t rate)
 int
 set_vf_rate_limit(portid_t port_id, uint16_t vf, uint16_t rate, uint64_t q_msk)
 {
+        (void)vf;
+	(void)rate;
+	(void)q_msk;
 	int diag = -ENOTSUP;
 
 #ifdef RTE_LIBRTE_IXGBE_PMD

--- a/drivers/net/dpaa/dpaa_ethdev.c
+++ b/drivers/net/dpaa/dpaa_ethdev.c
@@ -171,6 +171,7 @@ static void dpaa_eth_dev_info(struct rte_eth_dev *dev,
 
 	PMD_INIT_FUNC_TRACE();
 
+        dev_info->driver_name = dev->device->driver->name;
 	dev_info->max_rx_queues = dpaa_intf->nb_rx_queues;
 	dev_info->max_tx_queues = dpaa_intf->nb_tx_queues;
 	dev_info->min_rx_bufsize = DPAA_MIN_RX_BUF_SIZE;
@@ -788,7 +789,7 @@ static int dpaa_eth_dev_init(struct rte_eth_dev *eth_dev)
 }
 
 static int
-rte_dpaa_probe(struct rte_dpaa_driver *dpaa_drv __rte_unused,
+rte_dpaa_probe(struct rte_dpaa_driver *dpaa_drv,
 			   struct rte_dpaa_device *dpaa_dev)
 {
 	int diag;
@@ -842,6 +843,7 @@ rte_dpaa_probe(struct rte_dpaa_driver *dpaa_drv __rte_unused,
 	}
 
 	eth_dev->device = &dpaa_dev->device;
+        eth_dev->device->driver = &dpaa_drv->driver;
 	dpaa_dev->eth_dev = eth_dev;
 	eth_dev->data->rx_mbuf_alloc_failed = 0;
 

--- a/drivers/net/dpaa/dpaa_rxtx.c
+++ b/drivers/net/dpaa/dpaa_rxtx.c
@@ -296,7 +296,7 @@ static inline void dpaa_checksum_offload(struct rte_mbuf *mbuf,
 	fd->cmd = DPAA_FD_CMD_RPD | DPAA_FD_CMD_DTC;
 }
 
-struct rte_mbuf *dpaa_eth_sg_to_mbuf(struct qm_fd *fd, uint32_t ifid)
+static struct rte_mbuf *dpaa_eth_sg_to_mbuf(struct qm_fd *fd, uint32_t ifid)
 {
 	struct pool_info_entry *bp_info = DPAA_BPID_TO_POOL_INFO(fd->bpid);
 	struct rte_mbuf *first_seg, *prev_seg, *cur_seg, *temp;
@@ -475,7 +475,7 @@ static struct rte_mbuf *dpaa_get_dmable_mbuf(struct rte_mbuf *mbuf,
 	return dpaa_mbuf;
 }
 
-int dpaa_eth_mbuf_to_sg_fd(struct rte_mbuf *mbuf,
+static int dpaa_eth_mbuf_to_sg_fd(struct rte_mbuf *mbuf,
 		struct qm_fd *fd,
 		uint32_t bpid)
 {


### PR DESCRIPTION
2 commits:
- add 'static' modifier as the function is only used in dpaa_rxtx.c file
- driver name is used by rte_eth_dev_info which is also used in VPP.
